### PR TITLE
add toml example

### DIFF
--- a/hello.toml
+++ b/hello.toml
@@ -1,0 +1,1 @@
+subdir/hello.toml

--- a/subdir/hello.toml
+++ b/subdir/hello.toml
@@ -1,0 +1,33 @@
+# This is a TOML document.
+
+title = "TOML Example"
+
+[owner]
+name = "Tom Preston-Werner"
+dob = 1979-05-27T07:32:00-08:00 # First class dates
+
+[database]
+server = "192.168.1.1"
+ports = [ 8001, 8001, 8002 ]
+connection_max = 5000
+enabled = true
+
+[servers]
+
+  # Indentation (tabs and/or spaces) is allowed but not required
+  [servers.alpha]
+  ip = "10.0.0.1"
+  dc = "eqdc10"
+
+  [servers.beta]
+  ip = "10.0.0.2"
+  dc = "eqdc10"
+
+[clients]
+data = [ ["gamma", "delta"], [1, 2] ]
+
+# Line breaks are OK when inside arrays
+hosts = [
+  "alpha",
+  "omega"
+]


### PR DESCRIPTION
shows that syntax highlighting is broken for symbolic links.

thanks for making this repo, it made it easy for me to add this example to the discussion.